### PR TITLE
fix: Update @ensoai/esop-models to version 0.0.7 and adjust user API response structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-ses": "^3.864.0",
                 "@aws-sdk/client-sesv2": "^3.864.0",
-                "@ensoai/esop-models": "0.0.6",
+                "@ensoai/esop-models": "0.0.7",
                 "cors": "^2.8.5",
                 "dotenv": "^16.4.7",
                 "express": "^4.21.2",
@@ -785,9 +785,9 @@
             }
         },
         "node_modules/@ensoai/esop-models": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.0.6.tgz",
-            "integrity": "sha512-8U5p8Z4mC0y2o1g1ayWdMOq1UJUq8OfZbbKuHr0MAB1ZqVhfxq1A32s8TEwG5eVf8kBRp0jwC+b9d6jMkNBt3Q==",
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.0.7.tgz",
+            "integrity": "sha512-cp7hMRAmXwpiUEvFUaaQ3HwQCENmsUAHZRaGUl7PbtNycalCckJNgAXvJGnq3/uKVaEviFRgZCu7k3ZKV4lR7A==",
             "license": "ISC",
             "dependencies": {
                 "bcryptjs": "^3.0.2",

--- a/src/__tests__/apis/user.test.js
+++ b/src/__tests__/apis/user.test.js
@@ -136,7 +136,7 @@ describe('Tests for current user api', async () => {
         expect(response.body.message).to.equal('Success');
         expect(response.body.data).to.be.an('object');
         expect(response.body.data).to.not.have.property('password');
-        expect(response.body.data).to.have.property('Organisation');
+        expect(response.body.data.user).to.have.property('Organisation');
     });
 
     it('Should be able to fetch current user for super admin', async () => {
@@ -147,7 +147,7 @@ describe('Tests for current user api', async () => {
         expect(response.body.message).to.equal('Success');
         expect(response.body.data).to.be.an('object');
         expect(response.body.data).to.not.have.property('password');
-        expect(response.body.data).to.have.property('Organisation');
+        expect(response.body.data.user).to.have.property('Organisation');
     });
 });
 

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -155,7 +155,10 @@ export const getMe = async (req, res) => {
         const userService = new UserService(req);
         const user = await userService.getUserById(req.user.id);
 
-        res.sendSuccess(user);
+        res.sendSuccess({
+            user,
+            policies: req.policies,
+        });
     } catch (e) {
         logger.error(e);
         res.sendError([e.message], 'Error', 400);

--- a/swagger/swagger-output.json
+++ b/swagger/swagger-output.json
@@ -1,415 +1,391 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "title": "API documentation",
-    "description": "APIs for exprees app",
-    "version": "1.0.0"
-  },
-  "host": "127.0.0.1:3002",
-  "basePath": "/",
-  "schemes": [
-    "http"
-  ],
-  "paths": {
-    "/": {
-      "get": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
+    "swagger": "2.0",
+    "info": {
+        "title": "API documentation",
+        "description": "APIs for exprees app",
+        "version": "1.0.0"
     },
-    "/me": {
-      "get": {
-        "tags": [
-          "Manage Users"
-        ],
-        "description": "API to get current user",
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/auth/login": {
-      "post": {
-        "tags": [
-          "Auth"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "example": "any"
-                },
-                "password": {
-                  "example": "any"
+    "host": "127.0.0.1:3002",
+    "basePath": "/",
+    "schemes": ["http"],
+    "paths": {
+        "/": {
+            "get": {
+                "description": "",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
                 }
-              }
             }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/organisations/": {
-      "get": {
-        "tags": [
-          "Manage Organisations"
-        ],
-        "description": "Get all organisations  *",
-        "parameters": [
-          {
-            "name": "page",
-            "description": "Page number",
-            "required": false,
-            "type": "integer",
-            "in": "query"
-          },
-          {
-            "name": "limit",
-            "description": "Number of items per page",
-            "required": false,
-            "type": "integer",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Manage Organisations"
-        ],
-        "description": "Create an organisation",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "example": "any"
-                },
-                "firstName": {
-                  "example": "any"
-                },
-                "lastName": {
-                  "example": "any"
-                },
-                "email": {
-                  "example": "any"
-                },
-                "password": {
-                  "example": "any"
+        },
+        "/me": {
+            "get": {
+                "tags": ["Manage Users"],
+                "description": "API to get current user",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
                 }
-              }
             }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/organisations/{id}": {
-      "put": {
-        "tags": [
-          "Manage Organisations"
-        ],
-        "description": "Update an organisation",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "example": "any"
-                },
-                "context": {
-                  "example": "any"
+        },
+        "/auth/login": {
+            "post": {
+                "tags": ["Auth"],
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "email": {
+                                    "example": "any"
+                                },
+                                "password": {
+                                    "example": "any"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
                 }
-              }
             }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Manage Organisations"
-        ],
-        "description": "Delete an organisation",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/roles/": {
-      "get": {
-        "tags": [
-          "Roles"
-        ],
-        "description": "API to get all roles",
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/users/": {
-      "post": {
-        "tags": [
-          "Manage Users"
-        ],
-        "description": "API to create a new user",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "firstName": {
-                  "example": "any"
-                },
-                "lastName": {
-                  "example": "any"
-                },
-                "email": {
-                  "example": "any"
-                },
-                "password": {
-                  "example": "any"
-                },
-                "roles": {
-                  "example": "any"
-                },
-                "notify": {
-                  "example": "any"
+        },
+        "/organisations/": {
+            "get": {
+                "tags": ["Manage Organisations"],
+                "description": "Get all organisations  *",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "description": "Page number",
+                        "required": false,
+                        "type": "integer",
+                        "in": "query"
+                    },
+                    {
+                        "name": "limit",
+                        "description": "Number of items per page",
+                        "required": false,
+                        "type": "integer",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
                 }
-              }
+            },
+            "post": {
+                "tags": ["Manage Organisations"],
+                "description": "Create an organisation",
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "example": "any"
+                                },
+                                "firstName": {
+                                    "example": "any"
+                                },
+                                "lastName": {
+                                    "example": "any"
+                                },
+                                "email": {
+                                    "example": "any"
+                                },
+                                "password": {
+                                    "example": "any"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
             }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
+        },
+        "/organisations/{id}": {
+            "put": {
+                "tags": ["Manage Organisations"],
+                "description": "Update an organisation",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "example": "any"
+                                },
+                                "context": {
+                                    "example": "any"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Manage Organisations"],
+                "description": "Delete an organisation",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/roles/": {
+            "get": {
+                "tags": ["Roles"],
+                "description": "API to get all roles",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/users/": {
+            "post": {
+                "tags": ["Manage Users"],
+                "description": "API to create a new user",
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "firstName": {
+                                    "example": "any"
+                                },
+                                "lastName": {
+                                    "example": "any"
+                                },
+                                "email": {
+                                    "example": "any"
+                                },
+                                "password": {
+                                    "example": "any"
+                                },
+                                "roles": {
+                                    "example": "any"
+                                },
+                                "notify": {
+                                    "example": "any"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "get": {
+                "tags": ["Manage Users"],
+                "description": "API to get all users",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "description": "Page number",
+                        "required": false,
+                        "type": "integer",
+                        "in": "query"
+                    },
+                    {
+                        "name": "limit",
+                        "description": "Number of items per page",
+                        "required": false,
+                        "type": "integer",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/users/{id}": {
+            "put": {
+                "tags": ["Manage Users"],
+                "description": "API to update a user",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Manage Users"],
+                "description": "API to delete a user",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
         }
-      },
-      "get": {
-        "tags": [
-          "Manage Users"
-        ],
-        "description": "API to get all users",
-        "parameters": [
-          {
-            "name": "page",
-            "description": "Page number",
-            "required": false,
-            "type": "integer",
-            "in": "query"
-          },
-          {
-            "name": "limit",
-            "description": "Number of items per page",
-            "required": false,
-            "type": "integer",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
     },
-    "/users/{id}": {
-      "put": {
-        "tags": [
-          "Manage Users"
-        ],
-        "description": "API to update a user",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Manage Users"
-        ],
-        "description": "API to delete a user",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        }
-      }
-    }
-  },
-  "definitions": {
-    "User": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "number",
-          "example": 1
-        },
-        "firstName": {
-          "type": "string",
-          "example": "John"
-        },
-        "lastName": {
-          "type": "string",
-          "example": "Doe"
-        },
-        "email": {
-          "type": "string",
-          "example": "john.doe@example.com"
-        },
-        "OrganisationId": {
-          "type": "number",
-          "example": 1
-        },
-        "roles": {
-          "type": "array",
-          "items": {
+    "definitions": {
+        "User": {
             "type": "object",
             "properties": {
-              "id": {
-                "type": "number",
-                "example": 1
-              },
-              "name": {
-                "type": "string",
-                "example": "Admin"
-              }
+                "id": {
+                    "type": "number",
+                    "example": 1
+                },
+                "firstName": {
+                    "type": "string",
+                    "example": "John"
+                },
+                "lastName": {
+                    "type": "string",
+                    "example": "Doe"
+                },
+                "email": {
+                    "type": "string",
+                    "example": "john.doe@example.com"
+                },
+                "OrganisationId": {
+                    "type": "number",
+                    "example": 1
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "number",
+                                "example": 1
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Admin"
+                            }
+                        }
+                    }
+                },
+                "createdAt": {
+                    "type": "string",
+                    "example": "2025-08-11T00:00:00.000Z"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "example": "2025-08-11T00:00:00.000Z"
+                }
             }
-          }
         },
-        "createdAt": {
-          "type": "string",
-          "example": "2025-08-11T00:00:00.000Z"
-        },
-        "updatedAt": {
-          "type": "string",
-          "example": "2025-08-11T00:00:00.000Z"
-        }
-      }
-    },
-    "UsersResponse": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "example": "Success"
-        },
-        "data": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/User"
-              }
-            },
-            "total": {
-              "type": "number",
-              "example": 1
-            },
-            "page": {
-              "type": "number",
-              "example": 1
-            },
-            "limit": {
-              "type": "number",
-              "example": 10
+        "UsersResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success"
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/User"
+                            }
+                        },
+                        "total": {
+                            "type": "number",
+                            "example": 1
+                        },
+                        "page": {
+                            "type": "number",
+                            "example": 1
+                        },
+                        "limit": {
+                            "type": "number",
+                            "example": 10
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
-    },
-    "UpdateUserResponse": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "example": "Success"
         },
-        "data": {
-          "$ref": "#/definitions/User"
+        "UpdateUserResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success"
+                },
+                "data": {
+                    "$ref": "#/definitions/User"
+                }
+            }
         }
-      }
+    },
+    "components": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            }
+        }
     }
-  },
-  "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
-      }
-    }
-  }
 }


### PR DESCRIPTION
This pull request updates the response structure for the current user API and refines related tests and documentation. The main change is that the API now returns the user object nested under a `user` key, along with associated policies. The test cases and Swagger documentation have been updated to reflect this new response format and to improve consistency.

**API response structure changes:**

* The `getMe` controller now sends the user object nested under the `user` key and includes `policies` in the response. (`src/controllers/user.controller.js`)

**Test updates:**

* Test assertions for the current user API have been updated to check for the `Organisation` property inside `response.body.data.user` instead of directly under `response.body.data`. (`src/__tests__/apis/user.test.js`) [[1]](diffhunk://#diff-825c0febc5c938637e41ae4c9eb71554b855c3ee996aaa2f155647cc834a1df5L139-R139) [[2]](diffhunk://#diff-825c0febc5c938637e41ae4c9eb71554b855c3ee996aaa2f155647cc834a1df5L150-R150)

**Documentation and formatting improvements:**

* Swagger documentation (`swagger/swagger-output.json`) has been updated to use a more compact array format for `tags` and other minor formatting improvements across multiple endpoints. [[1]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L10-R10) [[2]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L26-R24) [[3]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L39-R35) [[4]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L69-R63) [[5]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L96-R88) [[6]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L135-R125) [[7]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L169-R157) [[8]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L190-R176) [[9]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L203-R187) [[10]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L243-R225) [[11]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L272-R252) [[12]](diffhunk://#diff-7675c1473c6a33e25a0b4a3677b87b0f4aadf769be63c0989f822d1bb2666829L291-R269)