### PR TITLE
Feat/plan apis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@aws-sdk/client-ses": "^3.864.0",
                 "@aws-sdk/client-sesv2": "^3.864.0",
                 "@aws-sdk/lib-storage": "^3.864.0",
-                "@ensoai/esop-models": "0.3.1-dev.0",
+                "@ensoai/esop-models": "0.3.2-dev.0",
                 "cors": "^2.8.5",
                 "date-fns": "^4.1.0",
                 "dotenv": "^16.4.7",
@@ -1089,9 +1089,9 @@
             }
         },
         "node_modules/@ensoai/esop-models": {
-            "version": "0.3.1-dev.0",
-            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.3.1-dev.0.tgz",
-            "integrity": "sha512-mLHSGhReNgqFs9O1KUTEl2knOLH8lGXMZzuDWQoFSyIhOZvgspKGSryDEXZm5dUFVA/n9FdYhEiLG/Ik65ZI6g==",
+            "version": "0.3.2-dev.0",
+            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.3.2-dev.0.tgz",
+            "integrity": "sha512-vZOm+FJO9N1AlkU8Amns+RIV+qvht7MbhnY8ergrX752ZEESp1oTh84Z7ZRGNSBFO++htbjcG+PK/Tb4eLxnaw==",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.864.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@aws-sdk/client-ses": "^3.864.0",
                 "@aws-sdk/client-sesv2": "^3.864.0",
                 "@aws-sdk/lib-storage": "^3.864.0",
-                "@ensoai/esop-models": "0.2.1-dev.0",
+                "@ensoai/esop-models": "0.3.1-dev.0",
                 "cors": "^2.8.5",
                 "date-fns": "^4.1.0",
                 "dotenv": "^16.4.7",
@@ -1089,9 +1089,9 @@
             }
         },
         "node_modules/@ensoai/esop-models": {
-            "version": "0.2.1-dev.0",
-            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.2.1-dev.0.tgz",
-            "integrity": "sha512-dp6zhH++289yGQTycKJ4plIWqm7hRNBuZwqbjf4cXcODEK+Wb2R2fGR8O1xhdBkWziqLwQxL0TlDz1ApkUUolw==",
+            "version": "0.3.1-dev.0",
+            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.3.1-dev.0.tgz",
+            "integrity": "sha512-mLHSGhReNgqFs9O1KUTEl2knOLH8lGXMZzuDWQoFSyIhOZvgspKGSryDEXZm5dUFVA/n9FdYhEiLG/Ik65ZI6g==",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.864.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/client-ses": "^3.864.0",
         "@aws-sdk/client-sesv2": "^3.864.0",
         "@aws-sdk/lib-storage": "^3.864.0",
-        "@ensoai/esop-models": "0.2.2",
+        "@ensoai/esop-models": "0.3.1",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/client-ses": "^3.864.0",
         "@aws-sdk/client-sesv2": "^3.864.0",
         "@aws-sdk/lib-storage": "^3.864.0",
-        "@ensoai/esop-models": "0.3.1",
+        "@ensoai/esop-models": "0.3.2",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",

--- a/src/__tests__/apis/fsm.test.js
+++ b/src/__tests__/apis/fsm.test.js
@@ -47,7 +47,7 @@ describe('FSM API tests', () => {
         expect(response.body.data).to.be.an('array');
     });
 
-    it('should perform a transition on an invoice', async () => {
+    it('should perform a transition on a user', async () => {
         const response = await request(global.testServer)
             .post(`/objects/user/${user.id}/transition`)
             .set('Authorization', `Bearer ${adminToken}`)

--- a/src/__tests__/apis/plan.test.js
+++ b/src/__tests__/apis/plan.test.js
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../app.js'; // Adjust path if needed
+
+describe('Plan API', () => {
+    let createdPlanId;
+
+    it('should create a new plan', async () => {
+        const res = await request(app)
+            .post('/plans')
+            .set('Authorization', `Bearer ${global.defaultOrg.adminToken}`)
+            .send({ name: 'API Plan', size: 50, type: 'ESOP' });
+        expect(res.status).to.equal(200);
+        expect(res.body.data).to.have.property('id');
+        expect(res.body.data.name).to.equal('API Plan');
+        createdPlanId = res.body.data.id;
+    });
+
+    it('should get all plans', async () => {
+        const res = await request(app)
+            .get('/plans')
+            .set('Authorization', `Bearer ${global.defaultOrg.adminToken}`);
+        expect(res.status).to.equal(200);
+        expect(res.body.data).to.be.an('array');
+        expect(res.body.data[0]).to.have.property('name');
+    });
+
+    it('should update a plan', async () => {
+        const res = await request(app)
+            .put(`/plans/${createdPlanId}`)
+            .set('Authorization', `Bearer ${global.defaultOrg.adminToken}`)
+            .send({ name: 'API Plan Updated' });
+        expect(res.status).to.equal(200);
+        expect(res.body.data.name).to.equal('API Plan Updated');
+    });
+
+    it('SHould be able to approve a plan', async () => {
+        const res = await request(app)
+            .post(`/objects/plan/${createdPlanId}/transition`)
+            .set('Authorization', `Bearer ${global.defaultOrg.adminToken}`)
+            .send({ action: 'APPROVE', comments: 'Testing transition' });
+        expect(res.status).to.equal(200);
+        expect(res.body.data).to.have.property('status', 'active');
+    });
+
+    it('should delete a plan', async () => {
+        const res = await request(app)
+            .delete(`/plans/${createdPlanId}`)
+            .set('Authorization', `Bearer ${global.defaultOrg.adminToken}`);
+        expect(res.status).to.equal(200);
+        expect(res.body.data).to.have.property(
+            'message',
+            'Plan deleted successfully'
+        );
+    });
+
+    it('should return error for deleting non-existent plan', async () => {
+        const res = await request(app)
+            .delete(`/plans/999999`)
+            .set('Authorization', `Bearer ${global.defaultOrg.adminToken}`);
+        expect(res.status).to.equal(400);
+        expect(res.body.errors[0]).to.equal('Plan not found');
+    });
+});

--- a/src/__tests__/services/plan.service.test.js
+++ b/src/__tests__/services/plan.service.test.js
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import PlanService from '../../services/plan.service.js';
+
+describe('PlanService', () => {
+    let req, planService, createdPlan;
+
+    before(() => {
+        // Mock req with db.models.Plan
+        req = {
+            policies: [
+                {
+                    policy: [
+                        {
+                            action: [
+                                'PlanService:getPlans',
+                                'PlanService:createPlan',
+                                'PlanService:updatePlan',
+                                'PlanService:deletePlan',
+                            ],
+                        },
+                    ],
+                },
+            ],
+            user: {
+                id: 1,
+                OrganisationId: global.defaultOrg.id,
+            },
+            options: {
+                tenant_id: global.defaultOrg.id,
+            },
+        };
+        planService = new PlanService(req);
+    });
+
+    it('should create a plan', async () => {
+        const data = { name: 'New Plan', size: 100 };
+        createdPlan = await planService.createPlan(data);
+        expect(createdPlan).to.have.property('id');
+        expect(createdPlan.name).to.equal('New Plan');
+    });
+
+    it('should get all plans', async () => {
+        const plans = await planService.getPlans();
+        expect(plans).to.be.an('array');
+        expect(plans[0]).to.have.property('name', 'New Plan');
+    });
+
+    it('should update a plan', async () => {
+        const updated = await planService.updatePlan(createdPlan.id, {
+            name: 'Updated Plan',
+        });
+        expect(updated).to.have.property('name', 'Updated Plan');
+    });
+
+    it('should throw error if plan not found for update', async () => {
+        try {
+            await planService.updatePlan(999, { name: 'No Plan' });
+            throw new Error('Should have thrown');
+        } catch (err) {
+            expect(err.message).to.equal('Plan not found');
+        }
+    });
+
+    it('should delete a plan', async () => {
+        const result = await planService.deletePlan(createdPlan.id);
+        expect(result).to.have.property('message', 'Plan deleted successfully');
+    });
+
+    it('should throw error if plan not found for delete', async () => {
+        try {
+            await planService.deletePlan(createdPlan.id);
+            throw new Error('Should have thrown');
+        } catch (err) {
+            expect(err.message).to.equal('Plan not found');
+        }
+    });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ import roleRoutes from './routes/role.route.js';
 import userRoutes from './routes/user.route.js';
 import fsmRoutes from './routes/fsm.route.js';
 import versionRoutes from './routes/version.route.js';
+import planRoutes from './routes/plan.route.js';
 import { getMe } from './controllers/user.controller.js';
 
 const app = express();
@@ -70,5 +71,6 @@ app.use('/roles', roleRoutes);
 app.use('/users', userRoutes);
 app.use('/objects', fsmRoutes);
 app.use('/versions', versionRoutes);
+app.use('/plans', planRoutes);
 
 export default app; // Export for testing

--- a/src/controllers/plan.controller.js
+++ b/src/controllers/plan.controller.js
@@ -1,0 +1,62 @@
+import logger from '../logger.js';
+import PlanService from '../services/plan.service.js';
+
+export const getPlans = async (req, res) => {
+    /**
+     * #swagger.tags = ['Plans']
+     * #swagger.description = 'Get all plans'
+     */
+    try {
+        const planService = new PlanService(req);
+        const plans = await planService.getPlans();
+        res.sendSuccess(plans);
+    } catch (err) {
+        logger.error(err);
+        res.sendError([err.message], 'Error', 400);
+    }
+};
+
+export const createPlan = async (req, res) => {
+    /**
+     * #swagger.tags = ['Plans']
+     * #swagger.description = 'Create a new plan'
+     */
+    try {
+        const planService = new PlanService(req);
+        const plan = await planService.createPlan(req.body);
+        res.sendSuccess(plan, 'Plan created successfully');
+    } catch (err) {
+        logger.error(err);
+        res.sendError([err.message], 'Error', 400);
+    }
+};
+
+export const updatePlan = async (req, res) => {
+    /**
+     * #swagger.tags = ['Plans']
+     * #swagger.description = 'Update a plan'
+     */
+    try {
+        const planService = new PlanService(req);
+        const plan = await planService.updatePlan(req.params.id, req.body);
+        res.sendSuccess(plan, 'Plan updated successfully');
+    } catch (err) {
+        logger.error(err);
+        res.sendError([err.message], 'Error', 400);
+    }
+};
+
+export const deletePlan = async (req, res) => {
+    /**
+     * #swagger.tags = ['Plans']
+     * #swagger.description = 'Delete a plan'
+     */
+    try {
+        const planService = new PlanService(req);
+        const result = await planService.deletePlan(req.params.id);
+        res.sendSuccess(result);
+    } catch (err) {
+        logger.error(err);
+        res.sendError([err.message], 'Error', 400);
+    }
+};

--- a/src/routes/plan.route.js
+++ b/src/routes/plan.route.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import {
+    getPlans,
+    createPlan,
+    updatePlan,
+    deletePlan,
+} from '../controllers/plan.controller.js';
+
+const router = express.Router();
+
+/**
+ * @route   GET /plans
+ * @desc    Get all plans
+ */
+router.get('/', getPlans);
+
+/**
+ * @route   POST /plans
+ * @desc    Create a new plan
+ */
+router.post('/', createPlan);
+
+/**
+ * @route   PUT /plans/:id
+ * @desc    Update a plan
+ */
+router.put('/:id', updatePlan);
+
+/**
+ * @route   DELETE /plans/:id
+ * @desc    Delete a plan
+ */
+router.delete('/:id', deletePlan);
+
+export default router;

--- a/swagger/swagger-output.json
+++ b/swagger/swagger-output.json
@@ -460,6 +460,62 @@
                     }
                 }
             }
+        },
+        "/plans/": {
+            "get": {
+                "tags": ["Plans"],
+                "description": "Get all plans",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Plans"],
+                "description": "Create a new plan",
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/plans/{id}": {
+            "put": {
+                "tags": ["Plans"],
+                "description": "Update a plan",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Plans"],
+                "description": "Delete a plan",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
         }
     },
     "definitions": {


### PR DESCRIPTION
This pull request introduces a new "Plan" feature to the codebase, providing full CRUD (Create, Read, Update, Delete) API endpoints, controller logic, service layer, and comprehensive test coverage. It also updates dependencies and documentation to support these changes.

**Plan API Feature Implementation**

* Added new controller `plan.controller.js` with handlers for listing, creating, updating, and deleting plans.
* Introduced `plan.route.js` and registered it in `app.js`, exposing `/plans` endpoints for CRUD operations. [[1]](diffhunk://#diff-5e45d135f0d4a9306c67ee94b303676a2b2487cc9434d1cb978e8f3fd73bf9f3R1-R35) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R18) [[3]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R74)
* Implemented service-level logic and tests in `plan.service.test.js` to verify plan creation, retrieval, update, and deletion, including error handling.
* Added API-level tests in `plan.test.js` to ensure endpoints behave as expected, including transitions and error cases.

**Documentation and Dependency Updates**

* Updated Swagger documentation to include the new `/plans` endpoints.
* Upgraded the `@ensoai/esop-models` dependency to version `0.3.2` in `package.json` for compatibility with the new feature.

**Other Test Maintenance**

* Updated an FSM API test to perform a transition on a user instead of an invoice, likely for consistency with new or existing test data.