### PR TITLE
fix: Update @ensoai/esop-models to version 0.4.1 and enhance grant service queries with ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@aws-sdk/client-ses": "^3.864.0",
                 "@aws-sdk/client-sesv2": "^3.864.0",
                 "@aws-sdk/lib-storage": "^3.864.0",
-                "@ensoai/esop-models": "0.4.0",
+                "@ensoai/esop-models": "0.4.1",
                 "cors": "^2.8.5",
                 "date-fns": "^4.1.0",
                 "dotenv": "^16.4.7",
@@ -1089,9 +1089,9 @@
             }
         },
         "node_modules/@ensoai/esop-models": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.4.0.tgz",
-            "integrity": "sha512-0nrdTl3kVVV605M4mRjjkDkIHsDDsxsFRPLVZzQPyy6BKu69eNFgGRp7/GgDBx92G4SXdEesYFV0Nra2E/gJag==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.4.1.tgz",
+            "integrity": "sha512-sV4YIP/KjjS1olVGlzPYZOod069Ylt8G7pCUoMaeiJW0xoSLwNXoOQVyfv5yT31hONvDa/YTBOSyNyi695z0Fw==",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.864.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/client-ses": "^3.864.0",
         "@aws-sdk/client-sesv2": "^3.864.0",
         "@aws-sdk/lib-storage": "^3.864.0",
-        "@ensoai/esop-models": "0.4.0",
+        "@ensoai/esop-models": "0.4.1",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",

--- a/src/services/grant.service.js
+++ b/src/services/grant.service.js
@@ -31,7 +31,10 @@ class GrantService extends TenantService {
                 this.req.db.models.User,
                 this.req.db.models.Plan,
                 this.req.db.models.Schedule,
-                this.req.db.models.Vest,
+                {
+                    model: this.req.db.models.Vest,
+                    order: [['date', 'ASC']],
+                },
             ],
         });
     }
@@ -88,7 +91,10 @@ class GrantService extends TenantService {
                 this.req.db.models.User,
                 this.req.db.models.Plan,
                 this.req.db.models.Schedule,
-                this.req.db.models.Vest,
+                {
+                    model: this.req.db.models.Vest,
+                    order: [['date', 'ASC']],
+                },
             ],
             order: [['createdAt', 'ASC']],
         });


### PR DESCRIPTION
This pull request updates the dependency version for `@ensoai/esop-models` and improves the ordering of associated `Vest` records in grant-related queries within the `GrantService`. The most important changes are grouped below:

Dependency Updates:

* Updated the `@ensoai/esop-models` dependency in `package.json` from version `0.4.0` to `0.4.1`, ensuring the project uses the latest model definitions.

GrantService Query Improvements:

* Modified the inclusion of the `Vest` model in grant-related queries within `GrantService` (`src/services/grant.service.js`) to explicitly order `Vest` records by their `date` in ascending order, improving data consistency and predictability. [[1]](diffhunk://#diff-34eed21911fe274ff0de8fbd875a49702410029ac1f3a24cad17bc2b0c44d7e7L34-R37) [[2]](diffhunk://#diff-34eed21911fe274ff0de8fbd875a49702410029ac1f3a24cad17bc2b0c44d7e7L91-R97)