### PR TITLE
Added api for plan summary and hook to reject grant.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@aws-sdk/client-ses": "^3.864.0",
                 "@aws-sdk/client-sesv2": "^3.864.0",
                 "@aws-sdk/lib-storage": "^3.864.0",
-                "@ensoai/esop-models": "0.4.2",
+                "@ensoai/esop-models": "0.4.5-dev.0",
                 "cors": "^2.8.5",
                 "date-fns": "^4.1.0",
                 "dotenv": "^16.4.7",
@@ -1089,9 +1089,9 @@
             }
         },
         "node_modules/@ensoai/esop-models": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.4.2.tgz",
-            "integrity": "sha512-9WUoFqTJYRuRFUygAlZfeTxn13jJ3dk+TkTt6E63IHf447/HRYXDvbBCGgk/z+lITopELTv98bV+1gqF+w/LfQ==",
+            "version": "0.4.5-dev.0",
+            "resolved": "https://registry.npmjs.org/@ensoai/esop-models/-/esop-models-0.4.5-dev.0.tgz",
+            "integrity": "sha512-fYQZw3Vr2yEcd4CT4JvD9+tq7VDB/O1Z2rBmG49ibTS5wzmxlp9m69vnPyLp1rKwy3ZRnRYtXcqvN3/U22mQ1w==",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.864.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/client-ses": "^3.864.0",
         "@aws-sdk/client-sesv2": "^3.864.0",
         "@aws-sdk/lib-storage": "^3.864.0",
-        "@ensoai/esop-models": "0.4.2",
+        "@ensoai/esop-models": "0.4.5-dev.0",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",

--- a/src/__tests__/apis/plan.test.js
+++ b/src/__tests__/apis/plan.test.js
@@ -34,6 +34,15 @@ describe('Plan API', () => {
         expect(res.body.data.name).to.equal('API Plan Updated');
     });
 
+    it('should get a plan with summary', async () => {
+        const res = await request(app)
+            .get(`/plans/${createdPlanId}/summary`)
+            .set('Authorization', `Bearer ${global.defaultOrg.adminToken}`);
+        expect(res.status).to.equal(200);
+        expect(res.body.data).to.have.property('id', createdPlanId);
+        expect(res.body.data).to.have.property('summary');
+    });
+
     it('SHould be able to approve a plan', async () => {
         const res = await request(app)
             .post(`/objects/plan/${createdPlanId}/transition`)

--- a/src/controllers/plan.controller.js
+++ b/src/controllers/plan.controller.js
@@ -60,3 +60,18 @@ export const deletePlan = async (req, res) => {
         res.sendError([err.message], 'Error', 400);
     }
 };
+
+export const getPlanWithSummary = async (req, res) => {
+    /**
+     * #swagger.tags = ['Plans']
+     * #swagger.description = 'Get a plan with summary'
+     */
+    try {
+        const planService = new PlanService(req);
+        const plan = await planService.getPlanWithSummary(req.params.id);
+        res.sendSuccess(plan);
+    } catch (err) {
+        logger.error(err);
+        res.sendError([err.message], 'Error', 400);
+    }
+};

--- a/src/hooks/fsm/grant.hooks.js
+++ b/src/hooks/fsm/grant.hooks.js
@@ -30,4 +30,14 @@ export default {
             return grant;
         },
     },
+    REJECT: {
+        postTransition: async ({ id, req, data }) => {
+            req.options.comments = data.comments;
+            const grantService = new GrantService(req);
+
+            await grantService.rejectGrant(id);
+
+            return { message: 'Grant rejected' };
+        },
+    },
 };

--- a/src/routes/plan.route.js
+++ b/src/routes/plan.route.js
@@ -4,6 +4,7 @@ import {
     createPlan,
     updatePlan,
     deletePlan,
+    getPlanWithSummary,
 } from '../controllers/plan.controller.js';
 
 const router = express.Router();
@@ -13,6 +14,12 @@ const router = express.Router();
  * @desc    Get all plans
  */
 router.get('/', getPlans);
+
+/**
+ * @route   GET /plans/:id/summary
+ * @desc    Get a plan with summary
+ */
+router.get('/:id/summary', getPlanWithSummary);
 
 /**
  * @route   POST /plans

--- a/src/services/grant.service.js
+++ b/src/services/grant.service.js
@@ -102,6 +102,25 @@ class GrantService extends TenantService {
             order: [['createdAt', 'ASC']],
         });
     }
+
+    async rejectGrant(id) {
+        const grant = await this.req.db.models.Grant.findByPk(id, this.options);
+        if (!grant) {
+            throw new Error('Grant not found');
+        }
+
+        // Cancel all the associated vests
+        await this.req.db.models.Vest.update(
+            { status: 'cancelled' },
+            {
+                where: { GrantId: id },
+                ...this.req.options,
+            }
+        );
+
+        await grant.refreshNumbers(this.options);
+        return grant;
+    }
 }
 
 export default GrantService;

--- a/src/services/plan.service.js
+++ b/src/services/plan.service.js
@@ -55,6 +55,109 @@ class PlanService extends TenantService {
         await plan.destroy(this.options);
         return { message: 'Plan deleted successfully' };
     }
+
+    async getPlanWithSummary(planId) {
+        const { Plan, Grant } = this.req.db.models;
+        const plan = await Plan.findByPk(planId, this.options);
+        if (!plan) throw new Error('Plan not found');
+        const planSize = parseFloat(plan.size) || 0;
+
+        const summary = await Grant.findOne({
+            ...this.options,
+            where: { PlanId: planId },
+            attributes: [
+                [
+                    Grant.sequelize.fn('SUM', Grant.sequelize.col('vested')),
+                    'vested',
+                ],
+                [
+                    Grant.sequelize.fn('SUM', Grant.sequelize.col('unvested')),
+                    'unvested',
+                ],
+                [
+                    Grant.sequelize.fn(
+                        'SUM',
+                        Grant.sequelize.col('surrendered')
+                    ),
+                    'surrendered',
+                ],
+                [
+                    Grant.sequelize.fn('SUM', Grant.sequelize.col('cancelled')),
+                    'cancelled',
+                ],
+                [
+                    Grant.sequelize.fn('SUM', Grant.sequelize.col('exercised')),
+                    'exercised',
+                ],
+                [
+                    Grant.sequelize.fn('SUM', Grant.sequelize.col('sold')),
+                    'sold',
+                ],
+            ],
+            raw: true,
+        });
+
+        // Parse and default to 0
+        const vested = parseFloat(summary.vested) || 0;
+        const unvested = parseFloat(summary.unvested) || 0;
+        const surrendered = parseFloat(summary.surrendered) || 0;
+        const cancelled = parseFloat(summary.cancelled) || 0;
+        const exercised = parseFloat(summary.exercised) || 0;
+        const sold = parseFloat(summary.sold) || 0;
+        const unsold = exercised - sold;
+
+        // Split and totals
+        return {
+            id: plan.id,
+            name: plan.name,
+            size: planSize,
+            summary: {
+                size: {
+                    value: planSize,
+                    split: {
+                        available: planSize - (vested + unvested),
+                        vested,
+                        unvested,
+                    },
+                    total: planSize,
+                },
+                granted: {
+                    value: vested + unvested + surrendered + cancelled,
+                    split: {
+                        vested,
+                        unvested,
+                        surrendered,
+                        cancelled,
+                    },
+                    total: vested + unvested + surrendered + cancelled,
+                },
+                vested: {
+                    value: exercised + (vested - exercised),
+                    split: {
+                        exercised,
+                        unexercised: vested - exercised,
+                    },
+                    total: vested,
+                },
+                exercised: {
+                    value: sold + unsold,
+                    split: {
+                        sold,
+                        unsold,
+                    },
+                    total: exercised,
+                },
+                surrendered: {
+                    value: surrendered,
+                    total: surrendered,
+                },
+                cancelled: {
+                    value: cancelled,
+                    total: cancelled,
+                },
+            },
+        };
+    }
 }
 
 export default PlanService;


### PR DESCRIPTION
This pull request introduces new functionality for summarizing plan data and improves grant management. The main highlights are the addition of a "get plan with summary" endpoint, supporting controller, service logic, and corresponding tests, as well as enhanced grant rejection handling.

**Plan summary feature:**

* Added a new endpoint `GET /plans/:id/summary` in `plan.route.js` to retrieve a plan along with a computed summary of grant statistics.
* Implemented the controller method `getPlanWithSummary` in `plan.controller.js` to handle summary requests.
* Added the service method `getPlanWithSummary` in `plan.service.js` that aggregates grant statistics (vested, unvested, surrendered, cancelled, exercised, sold) and returns a structured summary for the plan.
* Created a new test case in `plan.test.js` to verify the summary endpoint returns the expected data.

**Grant management improvements:**

* Added support for grant rejection: new `REJECT` transition hook in `grant.hooks.js` and corresponding `rejectGrant` method in `grant.service.js` to cancel associated vests and refresh grant numbers. [[1]](diffhunk://#diff-daf9c6b6faead5884dca3999ca263e98f149dcfd4f4c7c049b26c4c8a574f803R33-R42) [[2]](diffhunk://#diff-34eed21911fe274ff0de8fbd875a49702410029ac1f3a24cad17bc2b0c44d7e7R105-R123)

**Dependency update:**

* Updated the `@ensoai/esop-models` package version in `package.json` to `0.4.5-dev.0` for compatibility with new functionality.